### PR TITLE
Fix automated publishing pipeline

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -27,9 +27,10 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
-          registry-url: https://registry.npmjs.org/
+          node-version: '18.x'
+          registry-url: 'https://registry.npmjs.org/'
       - run: npm ci
-      - run: npm publish
+      - run: npm run build
+      - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/package.json
+++ b/package.json
@@ -18,5 +18,9 @@
   "homepage": "https://phyd3.bioinformatics-core.sites.vib.be",
   "bugs": {
     "url": "https://github.com/vibbits/phyd3-parser-compat/issues"
-  }
+  },
+  "files": [
+    "dist/**/*.js",
+    "dist/**/*.js.map"
+  ]
 }


### PR DESCRIPTION
Only publish built files and use the --access public flag (which is not default)